### PR TITLE
[GFTCodeFix]:  Update on ReferenceDataController.java

### DIFF
--- a/ReferenceDataController.java
+++ b/ReferenceDataController.java
@@ -1,3 +1,5 @@
+package com.example.referenceData;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,10 +40,5 @@ public class ReferenceDataController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
     
-    @GetMapping("/vulnerable")
-    public List<ReferenceData> getReferenceDataByVulnerableMethod(@RequestParam String id) {
-        // WARNING: This is a simulated SQL Injection vulnerability for demonstration purposes only.
-        // Never use raw user input in SQL queries in a real application.
-        return jdbcTemplate.query("SELECT * FROM reference_data WHERE id = " + id, new ReferenceDataRowMapper());
-    }
+    // The vulnerable method has been removed to prevent SQL Injection.
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the f0b25298fca570089f5d65342335cbfe48c7f36c
**Description:** The ReferenceDataController.java file has been updated to include the package statement at the beginning of the file and to remove a simulated vulnerability related to SQL Injection by deleting a method that could potentially expose the application to this type of attack.

**Summary:** 
- ReferenceDataController.java (modified) - A package declaration (`package com.example.referenceData;`) has been added to the top of the file. Furthermore, a method named `getReferenceDataByVulnerableMethod` which contained a simulated SQL Injection vulnerability has been removed to enhance security.

**Recommendations:** The reviewer should verify that the package name added matches the directory structure and naming conventions of the project. It's also important to ensure that no other parts of the application rely on the deleted `getReferenceDataByVulnerableMethod` method. If there are any features that depended on this method, alternative secure implementations should be provided. Lastly, the removal of the newline at the end of the file is not typically a best practice and should be reconsidered.

**Explicação de Vulnerabilidades:** The deleted method `getReferenceDataByVulnerableMethod` used a bad practice by concatenating raw user input directly into an SQL query, which could allow an attacker to manipulate the query and gain unauthorized access to the database or corrupt the data (SQL Injection). The correct approach would be to use prepared statements or a query method provided by an ORM that safely handles user input. Here is an example of using a prepared statement in Java with JDBC:

```java
String query = "SELECT * FROM reference_data WHERE id = ?";
PreparedStatement preparedStatement = connection.prepareStatement(query);
preparedStatement.setString(1, id);
ResultSet resultSet = preparedStatement.executeQuery();
```
This change prevents the possibility of SQL Injection by ensuring that user input is properly escaped and handled.