### PR TITLE
[GFTCodeFix]:  Update on ReferenceDataController.java

### DIFF
--- a/ReferenceDataController.java
+++ b/ReferenceDataController.java
@@ -1,6 +1,9 @@
+package com.example.reference;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
 
@@ -9,9 +12,11 @@ import java.util.List;
 public class ReferenceDataController {
 
     private final ReferenceDataService referenceDataService;
+    private final JdbcTemplate jdbcTemplate;
 
-    public ReferenceDataController(ReferenceDataService referenceDataService) {
+    public ReferenceDataController(ReferenceDataService referenceDataService, JdbcTemplate jdbcTemplate) {
         this.referenceDataService = referenceDataService;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     @GetMapping
@@ -42,6 +47,7 @@ public class ReferenceDataController {
     public List<ReferenceData> getReferenceDataByVulnerableMethod(@RequestParam String id) {
         // WARNING: This is a simulated SQL Injection vulnerability for demonstration purposes only.
         // Never use raw user input in SQL queries in a real application.
-        return jdbcTemplate.query("SELECT * FROM reference_data WHERE id = " + id, new ReferenceDataRowMapper());
+        String sql = "SELECT * FROM reference_data WHERE id = ?";
+        return jdbcTemplate.query(sql, new Object[]{id}, new ReferenceDataRowMapper());
     }
 }


### PR DESCRIPTION
```markdown
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 4564651976af26af8bdf1c03f66846c27a9d9fd9
**Description:** The pull request makes several changes to the `ReferenceDataController.java` file. It includes the addition of a package declaration, the `JdbcTemplate` dependency, and adjustments to constructor injection to accommodate the new dependency. Additionally, it addresses a simulated SQL Injection vulnerability by modifying the way SQL queries are executed.

**Summary:**
- `ReferenceDataController.java` (modified) - The file now declares its package as `com.example.reference`, which is a standard Java practice for organizing classes. The `JdbcTemplate` class from Spring framework has been added as a dependency to facilitate database operations. The constructor has been modified to accept `JdbcTemplate` as a new parameter, and it is being assigned to a class member. The method `getReferenceDataByVulnerableMethod` has been refactored to prevent SQL injection by using prepared statements with placeholders and parameter binding instead of string concatenation.

**Recommendations:** The reviewer should ensure that the package name `com.example.reference` aligns with the project's established naming conventions. The use of `JdbcTemplate` is a common practice in Spring applications for database interactions, and its inclusion should be reviewed for consistency with the rest of the application. The changes to the SQL query method should be thoroughly tested to ensure that the SQL injection vulnerability is indeed mitigated and that the method still returns the correct data. Additionally, check if other parts of the application are properly adapted to the new constructor signature of `ReferenceDataController`.

**Explicação de Vulnerabilidades:** The original code in `getReferenceDataByVulnerableMethod` used string concatenation to include user input (`id`) directly into the SQL query, leading to a SQL Injection vulnerability. This is a serious security flaw as it allows an attacker to manipulate the query to access or modify unauthorized data. The updated code uses a prepared statement with `?` as a placeholder for the parameter, and the `id` is passed as part of an array to the `query` method. This prevents SQL Injection by ensuring that the `id` is treated as a value rather than a part of the SQL command. The changes correctly mitigate the demonstrated SQL Injection vulnerability.

To further enhance security, ensure that all user inputs are validated and sanitized before being used in any context. It is also advisable to implement logging and monitoring mechanisms to detect and respond to potential security threats promptly.
```