### PR TITLE
[GFTCodeFix]:  Update on ReferenceDataController.java

### DIFF
--- a/ReferenceDataController.java
+++ b/ReferenceDataController.java
@@ -1,3 +1,5 @@
+package com.example.reference;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +28,7 @@ public class ReferenceDataController {
         return new ResponseEntity<>(updatedReferenceData, HttpStatus.OK);
     }
 
-    @PostMapping
+    @PostMapping("/create")
     public ResponseEntity<ReferenceData> createReferenceData(@RequestBody ReferenceData referenceData) {
         ReferenceData createdReferenceData = referenceDataService.createReferenceData(referenceData);
         return new ResponseEntity<>(createdReferenceData, HttpStatus.CREATED);
@@ -37,11 +39,4 @@ public class ReferenceDataController {
         referenceDataService.deleteReferenceData(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
-    @PostMapping
-    public ResponseEntity<ReferenceData> createReferenceData(@RequestBody ReferenceData referenceData) {
-    String secretKey = "hardcodedSecretKey"; // This is a severe security vulnerability
-    ReferenceData createdReferenceData = referenceDataService.createReferenceData(referenceData, secretKey);
-    return new ResponseEntity<>(createdReferenceData, HttpStatus.CREATED);
-}
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 47cd753c5a16d68c06711347b578393af1021bde
**Description:** This pull request introduces a modification to the `ReferenceDataController.java` file. It includes changes that organize the import/package statements, add a specific mapping for the create endpoint, and remove an insecure method of creating reference data that included a hardcoded secret key.

**Summary:**
- `ReferenceDataController.java` (modified) - The package declaration `com.example.reference` has been added to the top of the file. The `@PostMapping` annotation for the `createReferenceData` method now specifies a path `"/create"`. A duplicate and insecure `createReferenceData` method with a hardcoded secret key has been removed.

**Recommendations:** The reviewer should ensure that the correct package name is used according to the project's standards. The newly added path `"/create"` for the POST endpoint should be verified to ensure it matches the API design and documentation. It's important to test the creation of reference data to confirm that the functionality works as intended after the endpoint path change. Additionally, ensure that the removal of the insecure method doesn't affect any other parts of the application.

**Explicação de Vulnerabilidades:** The removed `createReferenceData` method contained a hardcoded secret key, which is a severe security vulnerability. Hardcoded secrets can be easily exposed if the codebase is compromised or inadvertently made public. The recommended way to handle secrets is to store them in environment variables or a secure vault solution, and access them via a secure method at runtime. This change effectively removes the vulnerability by eliminating the method.